### PR TITLE
Allow 'zmic' prefix for instrument check

### DIFF
--- a/src/Sound.cs
+++ b/src/Sound.cs
@@ -178,7 +178,7 @@ namespace instruments
                                     play = false;
                                 }
                                 assetLocation = instrumentFileLocation + "/" + octaveMap[note.octave];
-                                if (instrument == "mic")
+                                if (instrument == "mic" || instrument.StartsWith("zmic"))
                                 {
                                     Random rnd = new Random();
                                     int rNum = rnd.Next(0, 5); // A number between 0 and 4


### PR DESCRIPTION
It appears that you actually have two checks for this, I still can't build vsinstruments_base because your repo can't build when cloned, but this should hopefully work now.